### PR TITLE
STYLE: Fix typo in docstrings and error messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(SlicerEHRSandboc)
 set(EXTENSION_HOMEPAGE "https://www.slicer.org/wiki/Documentation/Nightly/Extensions/FHIRReader")
 set(EXTENSION_CATEGORY "Informatics")
 set(EXTENSION_CONTRIBUTORS "Stephen Crowell (Kitware), Ebrahim Ebrahim (Kitware), Andinet Enquobahrie (Kitware)")
-set(EXTENSION_DESCRIPTION "Read EHR data off a FHIR server. Currenlty reads Patient object and Observation Objects
+set(EXTENSION_DESCRIPTION "Read EHR data off a FHIR server. Currently reads Patient object and Observation Objects
 
 This work was supported by the National Institutes of Health under Award Number R42HL145669. The content is solely the responsibility of the authors and does not necessarily represent the official views of the National Institutes of Health.")
 set(EXTENSION_ICONURL "https://www.example.com/Slicer/Extensions/FHIRReader.png")

--- a/FHIRReader/FHIRReader.py
+++ b/FHIRReader/FHIRReader.py
@@ -466,7 +466,7 @@ class FHIRReaderLogic(ScriptedLoadableModuleLogic):
         :param fhirUrl: fhir server to connect to
         """            
         if (len(fhirUrl) == 0):
-            slicer.util.errorDisplay('Error intializing FHIR Client. Is FHIR Server empty?', windowTitle='Error')
+            slicer.util.errorDisplay('Error initializing FHIR Client. Is FHIR Server empty?', windowTitle='Error')
             return
 
         self.fhirURL = fhirUrl if (fhirUrl[-1] == '/') else fhirUrl + '/'
@@ -477,7 +477,7 @@ class FHIRReaderLogic(ScriptedLoadableModuleLogic):
         try:
             self.smart = client.FHIRClient(settings=settings)
         except BaseException as e:
-            slicer.util.errorDisplay('Error intializing FHIR Client. Does the server exist at {0} ?'.format(self.fhirURL), windowTitle='Error')
+            slicer.util.errorDisplay('Error initializing FHIR Client. Does the server exist at {0} ?'.format(self.fhirURL), windowTitle='Error')
             return
 
         try:
@@ -493,7 +493,7 @@ class FHIRReaderLogic(ScriptedLoadableModuleLogic):
         try:
             bundle = search.perform(self.smart.server)
         except BaseException as e:
-            slicer.util.errorDisplay('Error occured while communicating with FHIR Server.', windowTitle='Error')
+            slicer.util.errorDisplay('Error occurred while communicating with FHIR Server.', windowTitle='Error')
             return []
         settings = {
             'app_id': 'my_web_app',
@@ -510,7 +510,7 @@ class FHIRReaderLogic(ScriptedLoadableModuleLogic):
             try:
                 res = smart.server.request_json(bundle.link[1].url.split('/')[-1])
             except BaseException as e:
-                slicer.util.errorDisplay('Error occured while communicating with FHIR Server.', windowTitle='Error')
+                slicer.util.errorDisplay('Error occurred while communicating with FHIR Server.', windowTitle='Error')
                 return []
             bundle = b.Bundle(res)
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ Slicer extension for reading EHR data from a FHIR server.
 
 After the extension has been installed, swap to the FHIRReader module. The left side of the screen will have a FHIR url textbox with three selection menus below. The right side of the screen will have two empty tables for displaying patient information and observation information.
 
-Before attempting to connect to a server, first check to see if your Slicer has the [fhirclient](https://pypi.org/project/fhirclient/) python module installed. If you do not you not know if it isntalled or if it is not installed, there is an advanced tab at the bottom of the screen that contains a button to install the module for you.
+Before attempting to connect to a server, first check to see if your Slicer has the [fhirclient](https://pypi.org/project/fhirclient/) python module installed. If you do not you not know if it installed or if it is not installed, there is an advanced tab at the bottom of the screen that contains a button to install the module for you.
 
 With fhirclient installed, type the url of the FHIR server to connect to into the FHIR url textbox. The URL should follow the format of `http://localhost:2400/hapi-fhir-jpaserver/`. It is important to note the url should end with `hapi-fhir-jpaserver`.
 
 The system will begin to load all patients from the server. Depending on the amount of patients, it can take a few seconds to load all patients. The first selection menu will have the patients as options. The display string for each patient item will vary depending on the information available. If there are names on the server, each patient will be displayed as `Last Name, First Name`. If there are no names available, each patient will be displayed as `Patient id`. If this value is not present on the server, then the patient will be displayed as `Patient number` where *number* will increment with each patient.
 
-Double clicking on a patient will display the information on the left table and load all observations associated with the patient. The observations will populate the second selection menu. The observations will be grouped by types found. Double clicking an observation type will populate the left table with all of the patient's observation of that type.
+Double clicking on a patient will display the information on the left table and load all observations associated with the patient. The observations will populate the second selection menu. The observations will be grouped by types found. Double clicking an observation type will populate the left table with all of the patient's observations of that type.
 
 ## FHIR Server
 


### PR DESCRIPTION
Most of the issues were discovered using the codespell tool.

See https://github.com/codespell-project/codespell